### PR TITLE
Fix aborting before recording started

### DIFF
--- a/FDSoundActivatedRecorder/FDSoundActivatedRecorder/FDSoundActivatedRecorder.swift
+++ b/FDSoundActivatedRecorder/FDSoundActivatedRecorder/FDSoundActivatedRecorder.swift
@@ -229,7 +229,7 @@ open class FDSoundActivatedRecorder: NSObject, AVAudioRecorderDelegate {
     open func abort() {
         self.intervalTimer.invalidate()
         self.audioRecorder.stop()
-        if status == .recording {
+        if status != .inactive {
             status = .inactive
             self.delegate?.soundActivatedRecorderDidAbort(self)
             let fileManager: FileManager = FileManager.default


### PR DESCRIPTION
If status was .listening when abort was called, it would not actually abort or call the delegate method.